### PR TITLE
Add repository tag to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
+TAG:=mayfield/nginx_oauth2_proxy
+
 all: build
 
-
 build:
-	docker build -t nginx-oauth2-proxy .
+	docker build -t $(TAG) .


### PR DESCRIPTION
Use the [DockerHub][1] repository tag for local builds. Notice, this
will replace remote builds, if any exist.

[1]: https://hub.docker.com